### PR TITLE
update google tag manager and facebook

### DIFF
--- a/facebook.md
+++ b/facebook.md
@@ -23,3 +23,8 @@ http://staticxx.facebook.com/  <-- only for development
 ```
 https://www.facebook.com/tr/  <-- for Facebook Pixel tracking
 ```
+
+## form-action
+```
+	https://connect.facebook.net
+```

--- a/google-tag-manager.md
+++ b/google-tag-manager.md
@@ -24,6 +24,7 @@ https://tagmanager.google.com/  <-- for debugger
 ## frame-src
 ```
 https://www.googletagmanager.com/ns.html
+https://bid.g.doubleclick.net
 ```
 
 ## A note about Google Tag Manager Debug Mode


### PR DESCRIPTION
Upon checking https://report-uri.com it seems te following need to be addedd;

## Google

frame-src
```
https://bid.g.doubleclick.net
```

## Facebook

form-action
```
https://connect.facebook.net
```